### PR TITLE
Add bebop ip address as ROS parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ bebop_driver/scripts/meta/*.msg
 bebop_driver/scripts/meta/*.h
 bebop_driver/scripts/meta/*.cfg
 bebop_driver/scripts/meta/*.rst
+
+# Temporary files
+*~

--- a/bebop_driver/include/bebop_driver/bebop.h
+++ b/bebop_driver/include/bebop_driver/bebop.h
@@ -93,6 +93,7 @@ private:
   eARCONTROLLER_DEVICE_STATE device_state_;
   ARSAL_Sem_t state_sem_;
   boost::shared_ptr<VideoDecoder> video_decoder_ptr_;
+  const std::string bebop_ip_;
 
   // Navdata Callbacks
 #define DEFINE_SHARED_PTRS
@@ -138,7 +139,7 @@ public:
   inline bool IsConnected() const {return is_connected_;}
   inline bool IsStreamingStarted() const {return is_streaming_started_;}
 
-  explicit Bebop(ARSAL_Print_Callback_t custom_print_callback = 0);
+  explicit Bebop(ARSAL_Print_Callback_t custom_print_callback = 0, const std::string& = "192.168.42.1");
   ~Bebop();
 
   void Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh);

--- a/bebop_driver/include/bebop_driver/bebop.h
+++ b/bebop_driver/include/bebop_driver/bebop.h
@@ -93,7 +93,7 @@ private:
   eARCONTROLLER_DEVICE_STATE device_state_;
   ARSAL_Sem_t state_sem_;
   boost::shared_ptr<VideoDecoder> video_decoder_ptr_;
-  const std::string bebop_ip_;
+  std::string bebop_ip_;
 
   // Navdata Callbacks
 #define DEFINE_SHARED_PTRS
@@ -139,10 +139,10 @@ public:
   inline bool IsConnected() const {return is_connected_;}
   inline bool IsStreamingStarted() const {return is_streaming_started_;}
 
-  explicit Bebop(ARSAL_Print_Callback_t custom_print_callback = 0, const std::string& = "192.168.42.1");
+  explicit Bebop(ARSAL_Print_Callback_t custom_print_callback = 0);
   ~Bebop();
 
-  void Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh);
+  void Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh, const std::string& bebop_ip = "192.168.42.1");
   void StartStreaming();
 
   // Disable all data callback and streaming (nothrow)

--- a/bebop_driver/launch/bebop_node.launch
+++ b/bebop_driver/launch/bebop_node.launch
@@ -3,6 +3,7 @@
     <group ns="bebop">
         <node pkg="bebop_driver" name="bebop_driver" type="bebop_driver_node" output="screen">
             <param name="camera_info_url" value="package://bebop_driver/data/bebop_camera_calib.yaml" />
+            <param name="bebop_ip" value="192.168.0.101" />
             <rosparam command="load" file="$(find bebop_driver)/config/defaults.yaml" />
         </node>
     </group>

--- a/bebop_driver/launch/bebop_node.launch
+++ b/bebop_driver/launch/bebop_node.launch
@@ -3,7 +3,7 @@
     <group ns="bebop">
         <node pkg="bebop_driver" name="bebop_driver" type="bebop_driver_node" output="screen">
             <param name="camera_info_url" value="package://bebop_driver/data/bebop_camera_calib.yaml" />
-            <param name="bebop_ip" value="192.168.0.101" />
+            <param name="bebop_ip" value="192.168.42.1" />
             <rosparam command="load" file="$(find bebop_driver)/config/defaults.yaml" />
         </node>
     </group>

--- a/bebop_driver/launch/bebop_nodelet.launch
+++ b/bebop_driver/launch/bebop_nodelet.launch
@@ -7,6 +7,7 @@
         <node pkg="nodelet" type="nodelet" name="bebop_nodelet"
           args="load bebop_driver/BebopDriverNodelet bebop_nodelet_manager">
             <param name="camera_info_url" value="package://bebop_driver/data/bebop_camera_calib.yaml" />
+            <param name="bebop_ip" value="192.168.42.1" />
             <rosparam command="load" file="$(find bebop_driver)/config/defaults.yaml" />
         </node>
    </group>

--- a/bebop_driver/src/bebop.cpp
+++ b/bebop_driver/src/bebop.cpp
@@ -180,7 +180,7 @@ void Bebop::FrameReceivedCallback(ARCONTROLLER_Frame_t *frame, void *bebop_void_
 }
 
 
-Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback, const std::string& bebop_ip):
+Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback):
   is_connected_(false),
   is_streaming_started_(false),
   device_ptr_(NULL),
@@ -188,8 +188,7 @@ Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback, const std::string& be
   error_(ARCONTROLLER_OK),
   device_state_(ARCONTROLLER_DEVICE_STATE_MAX),
   video_decoder_ptr_(new bebop_driver::VideoDecoder()),
-  is_frame_avail_(false),
-  bebop_ip_(bebop_ip)
+  is_frame_avail_(false)
 //  out_file("/tmp/ts.txt")
 {
   // Redirect all calls to AR_PRINT_* to this function if provided
@@ -207,7 +206,7 @@ Bebop::~Bebop()
   if (device_controller_ptr_) ARCONTROLLER_Device_Delete(&device_controller_ptr_);
 }
 
-void Bebop::Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh)
+void Bebop::Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh, const std::string& bebop_ip)
 {
   try
   {
@@ -223,6 +222,9 @@ void Bebop::Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh)
     {
       throw std::runtime_error("Discovery failed: " + std::string(ARDISCOVERY_Error_ToString(error_discovery)));
     }
+    
+    // set/save ip
+    bebop_ip_ = bebop_ip;
 
     // TODO(mani-monaj): Make ip and port params
     error_discovery = ARDISCOVERY_Device_InitWifi(device_ptr_,

--- a/bebop_driver/src/bebop.cpp
+++ b/bebop_driver/src/bebop.cpp
@@ -180,7 +180,7 @@ void Bebop::FrameReceivedCallback(ARCONTROLLER_Frame_t *frame, void *bebop_void_
 }
 
 
-Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback):
+Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback, const std::string& bebop_ip):
   is_connected_(false),
   is_streaming_started_(false),
   device_ptr_(NULL),
@@ -188,7 +188,8 @@ Bebop::Bebop(ARSAL_Print_Callback_t custom_print_callback):
   error_(ARCONTROLLER_OK),
   device_state_(ARCONTROLLER_DEVICE_STATE_MAX),
   video_decoder_ptr_(new bebop_driver::VideoDecoder()),
-  is_frame_avail_(false)
+  is_frame_avail_(false),
+  bebop_ip_(bebop_ip)
 //  out_file("/tmp/ts.txt")
 {
   // Redirect all calls to AR_PRINT_* to this function if provided
@@ -226,7 +227,7 @@ void Bebop::Connect(ros::NodeHandle& nh, ros::NodeHandle& priv_nh)
     // TODO(mani-monaj): Make ip and port params
     error_discovery = ARDISCOVERY_Device_InitWifi(device_ptr_,
                                                   ARDISCOVERY_PRODUCT_ARDRONE, "Bebop",
-                                                  "192.168.42.1", 44444);
+                                                  bebop_ip_.c_str(), 44444);
 
     if (error_discovery != ARDISCOVERY_OK)
     {

--- a/bebop_driver/src/bebop_driver_nodelet.cpp
+++ b/bebop_driver/src/bebop_driver_nodelet.cpp
@@ -59,7 +59,6 @@ int BebopPrintToROSLogCB(eARSAL_PRINT_LEVEL level, const char *tag, const char *
 }  // namespace util
 
 BebopDriverNodelet::BebopDriverNodelet()
-  : bebop_ptr_(new bebop_driver::Bebop(util::BebopPrintToROSLogCB))
 {
   NODELET_INFO("Nodelet Cstr");
 }
@@ -77,8 +76,11 @@ void BebopDriverNodelet::onInit()
   // TODO(mani-monaj): Wrap all calls to .param() in a function call to enable logging
   const bool param_reset_settings = private_nh.param("reset_settings", false);
   const std::string& param_camera_info_url = private_nh.param<std::string>("camera_info_url", "");
+  const std::string& bebop_ip = private_nh.param<std::string>("bebop_ip", "192.168.42.1");
 
   param_frame_id_ = private_nh.param<std::string>("camera_frame_id", "camera");
+  
+  bebop_ptr_.reset(new bebop_driver::Bebop(util::BebopPrintToROSLogCB,bebop_ip));
 
   NODELET_INFO("Connecting to Bebop ...");
   try

--- a/bebop_driver/src/bebop_driver_nodelet.cpp
+++ b/bebop_driver/src/bebop_driver_nodelet.cpp
@@ -59,6 +59,7 @@ int BebopPrintToROSLogCB(eARSAL_PRINT_LEVEL level, const char *tag, const char *
 }  // namespace util
 
 BebopDriverNodelet::BebopDriverNodelet()
+ : bebop_ptr_(new bebop_driver::Bebop(util::BebopPrintToROSLogCB))
 {
   NODELET_INFO("Nodelet Cstr");
 }
@@ -76,16 +77,14 @@ void BebopDriverNodelet::onInit()
   // TODO(mani-monaj): Wrap all calls to .param() in a function call to enable logging
   const bool param_reset_settings = private_nh.param("reset_settings", false);
   const std::string& param_camera_info_url = private_nh.param<std::string>("camera_info_url", "");
-  const std::string& bebop_ip = private_nh.param<std::string>("bebop_ip", "192.168.42.1");
+  const std::string& param_bebop_ip = private_nh.param<std::string>("bebop_ip", "192.168.42.1");
 
   param_frame_id_ = private_nh.param<std::string>("camera_frame_id", "camera");
-  
-  bebop_ptr_.reset(new bebop_driver::Bebop(util::BebopPrintToROSLogCB,bebop_ip));
 
   NODELET_INFO("Connecting to Bebop ...");
   try
   {
-    bebop_ptr_->Connect(nh, private_nh);
+    bebop_ptr_->Connect(nh, private_nh, param_bebop_ip);
 
     if (param_reset_settings)
     {


### PR DESCRIPTION
I added the IP address of the bebop as a ROS parameter. This makes it easier to run when the bebop is connected as a client to a separate AP, e.g., for running multiple bebop simultaneously.
