### PR TITLE
Fix inline build of arsdk to use the frozen manifest (fixes #46)

### DIFF
--- a/bebop_driver/CMakeLists.txt
+++ b/bebop_driver/CMakeLists.txt
@@ -64,7 +64,7 @@ add_custom_target(ARSDKBuildUtils
   WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}/arsdk
   COMMAND curl -s https://storage.googleapis.com/git-repo-downloads/repo > ./repo
   COMMAND chmod a+x ./repo
-  COMMAND echo "y" | ./repo init -u https://github.com/Parrot-Developers/arsdk_manifests.git -b 2930cc7f7a79173d51c1fc167475fa9fa6650def
+  COMMAND echo "y" | ./repo init -u https://github.com/Parrot-Developers/arsdk_manifests.git -b 2930cc7f7a79173d51c1fc167475fa9fa6650def -m release.xml
   COMMAND ./repo sync
   # TODO
   COMMAND ./build.sh -p Unix-base -t build-sdk || xterm -e ./build.sh -p Unix-base -t build-sdk


### PR DESCRIPTION
- Prior to this release, the build script would always compile the
  development branch of ARSDK. This fix ensures that instead of
  `default.xml` manifest file - which represents the dev version of ARSDK
  package - `release.xml` is used by `repo`. This manifest file includes a
  certain hash for each ARSDK package that enforces a consistent build for
  ARSDK.
