### PR TITLE
Bug fix during catkin build

### DIFF
--- a/bebop_driver/CHANGELOG.rst
+++ b/bebop_driver/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package bebop_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.7.1 (2018-05-31)
+------------------
+* Fixed the bug appearing when you run the catkin build command
+* Contributors: Giuseppe Silano
+
 0.7.0 (2017-07-29)
 ------------------
 * SDK 3.12.6 support (except 64bit Ubuntu Xenial, working on fix)

--- a/bebop_driver/package.xml
+++ b/bebop_driver/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>bebop_driver</name>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <description>ROS driver for Parrot Bebop drone, based on Parrot’s official ARDroneSDK3</description>
 
   <maintainer email="mmonajje@sfu.ca">Mani Monajjemi</maintainer>

--- a/bebop_driver/src/bebop_video_decoder.cpp
+++ b/bebop_driver/src/bebop_video_decoder.cpp
@@ -133,7 +133,7 @@ bool VideoDecoder::ReallocateBuffers()
                      boost::lexical_cast<std::string>(codec_ctx_ptr_->width) +
                      " x " + boost::lexical_cast<std::string>(codec_ctx_ptr_->width));
 
-    const uint32_t num_bytes = avpicture_get_size(PIX_FMT_RGB24, codec_ctx_ptr_->width, codec_ctx_ptr_->width);
+    const uint32_t num_bytes = avpicture_get_size(AV_PIX_FMT_RGB24, codec_ctx_ptr_->width, codec_ctx_ptr_->width);
     frame_rgb_ptr_ = av_frame_alloc();
 
     ThrowOnCondition(!frame_rgb_ptr_, "Can not allocate memory for frames!");
@@ -143,12 +143,12 @@ bool VideoDecoder::ReallocateBuffers()
                      std::string("Can not allocate memory for the buffer: ") +
                      boost::lexical_cast<std::string>(num_bytes));
     ThrowOnCondition(0 == avpicture_fill(
-                       reinterpret_cast<AVPicture*>(frame_rgb_ptr_), frame_rgb_raw_ptr_, PIX_FMT_RGB24,
+                       reinterpret_cast<AVPicture*>(frame_rgb_ptr_), frame_rgb_raw_ptr_, AV_PIX_FMT_RGB24,
                        codec_ctx_ptr_->width, codec_ctx_ptr_->height),
                      "Failed to initialize the picture data structure.");
 
     img_convert_ctx_ptr_ = sws_getContext(codec_ctx_ptr_->width, codec_ctx_ptr_->height, codec_ctx_ptr_->pix_fmt,
-                                          codec_ctx_ptr_->width, codec_ctx_ptr_->height, PIX_FMT_RGB24,
+                                          codec_ctx_ptr_->width, codec_ctx_ptr_->height, AV_PIX_FMT_RGB24,
                                           SWS_FAST_BILINEAR, NULL, NULL, NULL);
   }
   catch (const std::runtime_error& e)


### PR DESCRIPTION
The bug that appears during the catkin build (Ubuntu 16.04, ROS Kinetic Kame) process, as before mentioned in the [#132](https://github.com/AutonomyLab/bebop_autonomy/issues/132), has been fixed in according to the commit [78071a14](https://github.com/FFmpeg/FFmpeg/commit/78071a14) of the FFmpeg repository.