### PR TITLE
Fix Virtual Camera movement mapping

### DIFF
--- a/docs/piloting.rst
+++ b/docs/piloting.rst
@@ -71,10 +71,10 @@ To move Bebop's virtual camera, publish a message of type `geometry_msgs/Twist <
 
 .. code-block:: text
 
-  angular.y (+)      tilt down
-            (-)      tilt up
-  angular.z (+)      pan left
-            (-)      pan right
+  angular.y (+)      tilt up
+            (-)      tilt down
+  angular.z (+)      pan right
+            (-)      pan left
 
 GPS Navigation
 ==============


### PR DESCRIPTION
Swap positive and negative values for angular.y and angular.z to fit results from testing on a Bebop2. Virtual camera appears to have range [-83,17] for angular.y and range [-35,35] for angular.z. Note that this does not fit the description above so perhaps it has changed between Bebop 1 and 2 in which case the + direction may have also changed. Please verify.