### PR TITLE
implementation of sendPilotingMoveBy method

### DIFF
--- a/bebop_driver/include/bebop_driver/bebop.h
+++ b/bebop_driver/include/bebop_driver/bebop.h
@@ -167,6 +167,7 @@ public:
   void PauseAutonomousFlight();
   void StopAutonomousFlight();
   void AnimationFlip(const uint8_t& anim_id);
+  void GoTo(const double& dx,const double& dy, const double& dz, const double& dpsi);
 
   // -1..1
   void Move(const double& roll, const double& pitch, const double& gaz_speed, const double& yaw_speed);

--- a/bebop_driver/include/bebop_driver/bebop_driver_nodelet.h
+++ b/bebop_driver/include/bebop_driver/bebop_driver_nodelet.h
@@ -129,6 +129,8 @@ private:
   ros::Publisher camera_joint_pub_;
   ros::Publisher gps_fix_pub_;
 
+  ros::Subscriber goto_sub_;
+
   boost::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_manager_ptr_;
   boost::shared_ptr<image_transport::ImageTransport> image_transport_ptr_;
   image_transport::CameraPublisher image_transport_pub_;
@@ -164,6 +166,7 @@ private:
   void TakeSnapshotCallback(const std_msgs::EmptyConstPtr& empty_ptr);
   void SetExposureCallback(const std_msgs::Float32ConstPtr& exposure_ptr);
   void ToggleRecordingCallback(const std_msgs::BoolConstPtr& toggle_ptr);
+  void GotoCallBack(const geometry_msgs::TwistConstPtr& twist_ptr);
 
   void ParamCallback(bebop_driver::BebopArdrone3Config &config, uint32_t level);
 

--- a/bebop_driver/src/bebop.cpp
+++ b/bebop_driver/src/bebop.cpp
@@ -502,6 +502,13 @@ void Bebop::StopAutonomousFlight()
         "Stop autonomous flight failed");
 }
 
+void Bebop::GoTo(const double &dx,const double &dy, const double &dz, const double &dpsi){
+  ThrowOnInternalError("Navigate Go to failed");
+  ThrowOnCtrlError(
+        device_controller_ptr_->aRDrone3->sendPilotingMoveBy( device_controller_ptr_->aRDrone3, dx,dy,dz,dpsi),
+                        "Navigate Go to failed");
+}
+
 void Bebop::AnimationFlip(const uint8_t &anim_id)
 {
   ThrowOnInternalError("Animation failed");

--- a/bebop_driver/src/bebop_driver_nodelet.cpp
+++ b/bebop_driver/src/bebop_driver_nodelet.cpp
@@ -146,6 +146,7 @@ void BebopDriverNodelet::onInit()
   snapshot_sub_ = nh.subscribe("snapshot", 10, &BebopDriverNodelet::TakeSnapshotCallback, this);
   exposure_sub_ = nh.subscribe("set_exposure", 10, &BebopDriverNodelet::SetExposureCallback, this);
   toggle_recording_sub_ = nh.subscribe("record", 10, &BebopDriverNodelet::ToggleRecordingCallback, this);
+  goto_sub_ = nh.subscribe("goto", 1, &BebopDriverNodelet::GotoCallBack, this);
 
   odom_pub_ = nh.advertise<nav_msgs::Odometry>("odom", 30);
   camera_joint_pub_ = nh.advertise<sensor_msgs::JointState>("joint_states", 10, true);
@@ -685,6 +686,22 @@ void BebopDriverNodelet::AuxThread()
     {
       NODELET_ERROR_STREAM("[AuxThread] " << e.what());
     }
+  }
+}
+
+void BebopDriverNodelet::GotoCallBack(const geometry_msgs::TwistConstPtr& twist_ptr)
+{
+  try
+  {
+    const double dx = twist_ptr->linear.x; //displacement along the front axis
+    const double dy = twist_ptr->linear.y; //displacement along the right axis
+    const double dz = twist_ptr->linear.z; //displacement along the down axis
+    const double dpsi =  twist_ptr->angular.z; // rotation of heading
+    bebop_ptr_->GoTo(dx,dy,dz,dpsi);
+  }
+  catch (const std::runtime_error& e)
+  {
+    ROS_ERROR_STREAM("[Goto] " << e.what());
   }
 }
 


### PR DESCRIPTION
## Goal:
The objective of this modification is to allow a Bepop library user to move a drone to a relative position directly

## Implementation
The implementation is based on the parrot sdk method *[sendPilotingMoveBy](https://developer.parrot.com/docs/bebop/#a-name-ardrone3-piloting-moveby-a)*


## Usage:

For using this implementation: send a *geomtry_msgs/Twist* like this:

| msg variables | attribution | action |
|---------------|-------------|--------|
|linear.x       | dx          | displacement along the front axis  |
|linear.y       | dy          | displacement along the right axis  |
|linear.z       | dz          | displacement along the down axis  |
|angular.x       | nothing          | nothing |
|angular.y       | nothing          | nothing |
|angular.z       | dpsi          |  rotation of heading |

at the topic **/bebop/goto**

## Test:

Compilation and tests have been done on this config:
* ros version: kinectic
* parrot_arsdk version: 3.12.6p1 (also work on 3.14.1)


## Example:
A video is available on Youtube at this adress: https://youtu.be/8RcVpDUoFJc
