### PR TITLE
fixed build bebop_driver on ROS Melodic

### DIFF
--- a/bebop_driver/src/bebop_video_decoder.cpp
+++ b/bebop_driver/src/bebop_video_decoder.cpp
@@ -90,11 +90,11 @@ bool VideoDecoder::InitCodec()
     codec_ctx_ptr_->width = 0;
     codec_ctx_ptr_->height = 0;
 
-    if (codec_ptr_->capabilities & CODEC_CAP_TRUNCATED)
+    if (codec_ptr_->capabilities & AV_CODEC_CAP_TRUNCATED)
     {
-      codec_ctx_ptr_->flags |= CODEC_FLAG_TRUNCATED;
+      codec_ctx_ptr_->flags |= AV_CODEC_FLAG_TRUNCATED;
     }
-    codec_ctx_ptr_->flags2 |= CODEC_FLAG2_CHUNKS;
+    codec_ctx_ptr_->flags2 |= AV_CODEC_FLAG2_CHUNKS;
 
     frame_ptr_ = av_frame_alloc();
     ThrowOnCondition(!frame_ptr_ , "Can not allocate memory for frames!");


### PR DESCRIPTION
This issue is relate to the FFMPEG headers > release 4.0. 

The name  of various constants got " AV_ " prefix, like AV_CODEC_CAP_TRUNCATED, AV_CODEC_FLAG_TRUNCATED, AV_CODEC_FLAG2_CHUNKS.